### PR TITLE
Fix DayNightManager null check

### DIFF
--- a/Assets/Scripts/UI/TimeOfDayUI.cs
+++ b/Assets/Scripts/UI/TimeOfDayUI.cs
@@ -12,9 +12,11 @@ namespace UI
         private void Start()
         {
             _dayNightManager = GameManager.Instance.DayNightManager;
-            if (_dayNightManager != null) return;
-            Debug.LogError("DayNightManager not found in GameManager.");
-            return; 
+            if (_dayNightManager == null)
+            {
+                Debug.LogError("DayNightManager not found in GameManager.");
+                return;
+            }
         }
 
         private void Update()


### PR DESCRIPTION
## Summary
- fix the null check when initializing `TimeOfDayUI` so the error message triggers only if the manager is missing

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848378a112083259eca4c9e26a249b5