### PR TITLE
Add server spawn helpers

### DIFF
--- a/Assets/Scripts/Creatures/Chickens/Chicks/Components/ChickGrowthHandler.cs
+++ b/Assets/Scripts/Creatures/Chickens/Chicks/Components/ChickGrowthHandler.cs
@@ -41,7 +41,7 @@ namespace Creatures.Chickens.Chicks.Components
             Debug.Log("Growth cooldown finished");
             if (!Owner) return;
 
-            _chickenSpawnerService.RequestSpawnChickenAt(transform.position, Owner.Chicken);
+            _chickenSpawnerService.SpawnChickenServer(transform.position, Owner.Chicken);
             NetworkServer.Destroy(Owner.gameObject);
         }
 

--- a/Assets/Scripts/Interactions/Objects/RoosterGeneratorMachine.cs
+++ b/Assets/Scripts/Interactions/Objects/RoosterGeneratorMachine.cs
@@ -16,7 +16,7 @@ namespace Interactions.Objects
         public override void OnInteract(GameObject interactor)
         {
             base.OnInteract(interactor); 
-            GameManager.Instance.ChickenSpawnerService.RequestSpawnRandomAt(spawnPoint, fixedType);
+            GameManager.Instance.ChickenSpawnerService.SpawnRandomServer(spawnPoint.position, fixedType, spawnPoint.rotation);
         }
     }
 }

--- a/Assets/Scripts/Players/PlayerInventory.cs
+++ b/Assets/Scripts/Players/PlayerInventory.cs
@@ -185,7 +185,7 @@ namespace Players
             var dropPos = transform.position + transform.forward * dropDistance;
 
             if (item.IsRooster)
-                GameManager.Instance.ChickenSpawnerService.RequestSpawnRoosterAt(dropPos, item.Chicken as Rooster);
+                GameManager.Instance.ChickenSpawnerService.SpawnRoosterServer(dropPos, item.Chicken as Rooster);
             else
             {
                 var data = GameManager.Instance.ContainerService.ItemDataContainer.Get(item.ItemId);


### PR DESCRIPTION
## Summary
- add Spawn*Server helper methods to `ChickenSpawnerService`
- use new helpers in `ChickGrowthHandler`, `RoosterGeneratorMachine`, `PlayerInventory`
- allow `SpawnEntityInternal` to take optional owner connection

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6848475681f48325a64aa478fafed50f