### PR TITLE
Fix Unity serialization of gene features

### DIFF
--- a/Assets/Scripts/Creatures/Genes/Base/GeneFeature.cs
+++ b/Assets/Scripts/Creatures/Genes/Base/GeneFeature.cs
@@ -1,13 +1,26 @@
 ﻿using System;
 using Creatures.Genes.Base.ScriptableObjects;
+using UnityEngine;
 
 namespace Creatures.Genes.Base
 {
     [Serializable]
     public abstract class GeneFeature : IGeneFeature
     {
-        public GeneFeatureType GeneFeatureType { get; set; }
-        public string Name { get; set; }
+        [SerializeField] private GeneFeatureType geneFeatureType;
+        [SerializeField] private string name;
+
+        public GeneFeatureType GeneFeatureType
+        {
+            get => geneFeatureType;
+            set => geneFeatureType = value;
+        }
+
+        public string Name
+        {
+            get => name;
+            set => name = value;
+        }
     }
     
     public interface IGeneFeature

--- a/Assets/Scripts/Creatures/Genes/Features/Base/AppearanceGeneFeature.cs
+++ b/Assets/Scripts/Creatures/Genes/Features/Base/AppearanceGeneFeature.cs
@@ -6,13 +6,49 @@ namespace Creatures.Genes.Features.Base
 {
     [Serializable]
     public class AppearanceGeneFeature :GeneFeature, IAppearanceGeneFeature
-    { 
-       [SerializeField] public Color ColorValue { get; set; }
-       [SerializeField]public Material MaterialValue { get; set; }
-       [SerializeField]public float SizeValue { get; set; }
-       [SerializeField]public Texture TextureValue { get; set; }
-       [SerializeField]public AppearanceGeneType AppearanceGeneType { get; set; }
-       [SerializeField]public AppearanceEffectType AppearanceEffectType { get; set; }
+    {
+        [SerializeField] private Color colorValue;
+        [SerializeField] private Material materialValue;
+        [SerializeField] private float sizeValue;
+        [SerializeField] private Texture textureValue;
+        [SerializeField] private AppearanceGeneType appearanceGeneType;
+        [SerializeField] private AppearanceEffectType appearanceEffectType;
+
+        public Color ColorValue
+        {
+            get => colorValue;
+            set => colorValue = value;
+        }
+
+        public Material MaterialValue
+        {
+            get => materialValue;
+            set => materialValue = value;
+        }
+
+        public float SizeValue
+        {
+            get => sizeValue;
+            set => sizeValue = value;
+        }
+
+        public Texture TextureValue
+        {
+            get => textureValue;
+            set => textureValue = value;
+        }
+
+        public AppearanceGeneType AppearanceGeneType
+        {
+            get => appearanceGeneType;
+            set => appearanceGeneType = value;
+        }
+
+        public AppearanceEffectType AppearanceEffectType
+        {
+            get => appearanceEffectType;
+            set => appearanceEffectType = value;
+        }
     }
 
     public interface IAppearanceGeneFeature : IGeneFeature

--- a/Assets/Scripts/Creatures/Genes/Features/Base/SkillGeneFeature.cs
+++ b/Assets/Scripts/Creatures/Genes/Features/Base/SkillGeneFeature.cs
@@ -1,15 +1,51 @@
 ﻿using Creatures.Genes.Base;
-
+using UnityEngine;
 namespace Creatures.Genes.Features.Base
 {
     public class SkillGeneFeature : GeneFeature,ISkillGeneFeature
     {
-        public string SkillName { get; set; }
-        public string SkillDescription { get; set;}
-        public int SkillLevel { get; set;}
-        public int SkillCooldown { get; set;}
-        public int SkillDuration { get;set; }
-        public SkillGeneType SkillGeneType { get; set; }
+        [SerializeField] private string skillName;
+        [SerializeField] private string skillDescription;
+        [SerializeField] private int skillLevel;
+        [SerializeField] private int skillCooldown;
+        [SerializeField] private int skillDuration;
+        [SerializeField] private SkillGeneType skillGeneType;
+
+        public string SkillName
+        {
+            get => skillName;
+            set => skillName = value;
+        }
+
+        public string SkillDescription
+        {
+            get => skillDescription;
+            set => skillDescription = value;
+        }
+
+        public int SkillLevel
+        {
+            get => skillLevel;
+            set => skillLevel = value;
+        }
+
+        public int SkillCooldown
+        {
+            get => skillCooldown;
+            set => skillCooldown = value;
+        }
+
+        public int SkillDuration
+        {
+            get => skillDuration;
+            set => skillDuration = value;
+        }
+
+        public SkillGeneType SkillGeneType
+        {
+            get => skillGeneType;
+            set => skillGeneType = value;
+        }
     }
     
     public interface ISkillGeneFeature : IGeneFeature

--- a/Assets/Scripts/Creatures/Genes/Features/Base/StatGeneFeature.cs
+++ b/Assets/Scripts/Creatures/Genes/Features/Base/StatGeneFeature.cs
@@ -1,13 +1,26 @@
 ﻿using Creatures.Chickens.Base.Components;
 using Creatures.Genes.Base;
+using UnityEngine;
 
 namespace Creatures.Genes.Features.Base
 {
     public class StatGeneFeature : GeneFeature, IStatGeneFeature
     {
-        public StatType StatType { get; set; }
-        public int Value { get; set; }
-    } 
+        [SerializeField] private StatType statType;
+        [SerializeField] private int value;
+
+        public StatType StatType
+        {
+            get => statType;
+            set => statType = value;
+        }
+
+        public int Value
+        {
+            get => value;
+            set => this.value = value;
+        }
+    }
     
     public interface IStatGeneFeature : IGeneFeature
     {


### PR DESCRIPTION
## Summary
- make gene feature types serializable by adding private backing fields
- expose public properties for each field

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848af3ee4b88325978516cc8c550b05